### PR TITLE
Keep empty files empty

### DIFF
--- a/flake8_coding.py
+++ b/flake8_coding.py
@@ -28,8 +28,12 @@ class CodingChecker(object):
         with open(self.filename) as f:
             # PEP-263 says: a magic comment must be placed into the source
             #               files either as first or second line in the file
-            for lineno in range(1, 3):
-                matched = re.search('coding[:=]\s*([-\w.]+)', f.readline(), re.IGNORECASE)
+            lines = f.readlines()[:2]
+            if len(lines) == 0:
+                raise StopIteration()
+
+            for lineno, line in enumerate(lines, start=1):
+                matched = re.search('coding[:=]\s*([-\w.]+)', line, re.IGNORECASE)
                 if matched:
                     if matched.group(1).lower() not in self.encodings:
                         yield lineno, 0, "C102 Unknown encoding found in coding magic comment", type(self)

--- a/run_tests.py
+++ b/run_tests.py
@@ -13,6 +13,12 @@ class TestFlake8Coding(unittest.TestCase):
         ret = list(checker.run())
         self.assertEqual(ret, [])
 
+    def test_empty_file(self):
+        checker = CodingChecker(None, 'testsuite/empty.py')
+        checker.encodings = ['latin-1', 'utf-8']
+        ret = list(checker.run())
+        self.assertEqual(ret, [])
+
     def test_has_latin1_coding_header(self):
         checker = CodingChecker(None, 'testsuite/latin1.py')
         checker.encodings = ['latin-1', 'utf-8']


### PR DESCRIPTION
`__init__.py` is the most prominent example, usually is only put on
a folder to turn it into a package, but no code is added there.
