### PR TITLE
Add support for no coding comment.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 1.1.2 (not released yet)
 ------------------------
+* Add option `no-accept-encodings`. If set, will warn for files containing a `coding:` magic comment.
 * Fix a bug
 
   - #4 stdin not supported

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,9 @@ accept-encodings
     Acceptable source code encodings for ``coding:`` magic comment.
     Default is ``latin-1, utf-8``.
 
+no-accept-encodings
+    If set, will warn for files containing a ``coding:`` magic comment.
+
 Requirements
 -------------
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -106,6 +106,29 @@ class TestFlake8Coding(unittest.TestCase):
             self.assertEqual(ret[0][1], 0)
             self.assertTrue(ret[0][2].startswith('C101 '))
 
+    @patch.object(sys, 'argv', ['', '--no-accept-encodings'])
+    def test_no_accept_encodings_sets_encodings_none(self):
+        try:
+            get_style_guide(parse_argv=True)  # parse arguments
+            self.assertTrue(CodingChecker.encodings is None)
+        finally:
+            if hasattr(CodingChecker, 'encodings'):
+                del CodingChecker.encodings
+
+    def test_encoding_none_with_no_coding_comment(self):
+        checker = CodingChecker(None, 'testsuite/nocoding.py')
+        checker.encodings = None
+        ret = list(checker.run())
+        self.assertEqual(ret, [])
+
+    def test_encoding_none_with_coding_comment(self):
+        checker = CodingChecker(None, 'testsuite/utf8.py')
+        checker.encodings = None
+        ret = list(checker.run())
+        self.assertEqual(len(ret), 1)
+        self.assertEqual(ret[0][0], 1)
+        self.assertEqual(ret[0][1], 0)
+        self.assertTrue(ret[0][2].startswith('C103 '))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Python3 encodes py files as utf-8 by default. Therefore, the coding
comment has little use for Python3 only projects. Adding a flake8 check
can help coding consistency.
