### PR TITLE
Fix ResourceWarning appearing when running run_tests.py.

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -95,7 +95,8 @@ class TestFlake8Coding(unittest.TestCase):
 
     @patch('pep8.stdin_get_value')
     def test_stdin(self, stdin_get_value):
-        stdin_get_value.return_value = open('testsuite/nocodings.py').read()
+        with open('testsuite/nocodings.py') as fp:
+            stdin_get_value.return_value = fp.read()
 
         for input in ['stdin', '-', None]:
             checker = CodingChecker(None, input)


### PR DESCRIPTION
Can appear as:

```
run_tests.py:98: ResourceWarning: unclosed file <_io.TextIOWrapper name='testsuite/nocodings.py' mode='r' encoding='UTF-8'>
  stdin_get_value.return_value = open('testsuite/nocodings.py').read()
```
