### PR TITLE
Fix no-accept-encodings to work in config files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ You can pass this as a command-line argument to ``flake8``, e.g.
 .. code-block:: ini
 
     [flake8]
-    no-accept-encodings
+    no-accept-encodings = True
 
 Rules
 -----

--- a/flake8_coding.py
+++ b/flake8_coding.py
@@ -19,7 +19,7 @@ class CodingChecker(object):
             help="Acceptable source code encodings for `coding:` magic comment"
         )
         parser.add_option(
-            '--no-accept-encodings', action='store_true',
+            '--no-accept-encodings', action='store_true', parse_from_config=True,
             help="Warn for files containing a `coding:` magic comment"
         )
 


### PR DESCRIPTION
I found with flake8 3.0.4 if I have bare `no-accept-encodings` in my config file, it just crashes, and it needs `no-accept-encodings = something` in the file. Then the `parse_from_config` flag is required on the option to indicate that as a flag it should indeed be parsed.
