### PR TITLE
Drop Python 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python: 2.7
 env:
   matrix:
-    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ file.
 Requirements
 -------------
 
-* Python 2.6, 2.7, 3.3, 3.4
+* Python 2.7, 3.3, 3.4
 * flake8
 
 License

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py34-check
+envlist=py27,py33,py34,py34-check
 
 [testenv]
 passenv=


### PR DESCRIPTION
As noted in #8 flake8 3.0.0+ doesn't support it, so this plugin shouldn't either. Fixes build.
