### PR TITLE
Use first line number for C101 message

### DIFF
--- a/flake8_coding.py
+++ b/flake8_coding.py
@@ -68,6 +68,6 @@ class CodingChecker(object):
                     break
             else:
                 if self.encodings:
-                    yield 0, 0, "C101 Coding magic comment not found", type(self)
+                    yield 1, 0, "C101 Coding magic comment not found", type(self)
         except IOError:
             pass

--- a/run_tests.py
+++ b/run_tests.py
@@ -47,7 +47,7 @@ class TestFlake8Coding(unittest.TestCase):
         checker.encodings = ['latin-1', 'utf-8']
         ret = list(checker.run())
         self.assertEqual(len(ret), 1)
-        self.assertEqual(ret[0][0], 0)
+        self.assertEqual(ret[0][0], 1)
         self.assertEqual(ret[0][1], 0)
         self.assertTrue(ret[0][2].startswith('C101 '))
 
@@ -71,7 +71,7 @@ class TestFlake8Coding(unittest.TestCase):
         checker.encodings = ['latin-1', 'utf-8']
         ret = list(checker.run())
         self.assertEqual(len(ret), 1)
-        self.assertEqual(ret[0][0], 0)
+        self.assertEqual(ret[0][0], 1)
         self.assertEqual(ret[0][1], 0)
         self.assertTrue(ret[0][2].startswith('C101 '))
 
@@ -110,7 +110,7 @@ class TestFlake8Coding(unittest.TestCase):
                 checker.encodings = ['latin-1', 'utf-8']
                 ret = list(checker.run())
                 self.assertEqual(len(ret), 1)
-                self.assertEqual(ret[0][0], 0)
+                self.assertEqual(ret[0][0], 1)
                 self.assertEqual(ret[0][1], 0)
                 self.assertTrue(ret[0][2].startswith('C101 '))
 


### PR DESCRIPTION
I use vs code with flake8 for linting and I faced with a bug:
```
Illegal argument: line must be non-negative.
```
That happens because the flake8-coding uses zero line number for generating C101 message. I think it should use the first line.
```
a magic comment must be placed into the source files either as first or second line in the file.
```